### PR TITLE
add product links and editor formatting

### DIFF
--- a/.agents/context/index.md
+++ b/.agents/context/index.md
@@ -33,7 +33,7 @@ working on Creed. Code remains canonical when documentation drifts.
 - Creed is a personal-context curation product, not a notes app, journal, memory feed, or generic AI wrapper.
 - Keep the file sacred, portable, high-signal, and worth reading.
 - Marketing and product UI should feel calm, premium, editorial, and document-first.
-- Never put personal information in source. Use environment-backed branding values.
+- Never put personal email or legal names in source. Use environment-backed branding values. Public product links are constants in `lib/branding.ts`.
 - Protect authentication, token hashing, encryption, RLS, and the static marketing layout boundaries.
 - Do not use em dashes in product copy, prompts, comments, or context.
 - Update context only when a durable product, architecture, decision, roadmap, brand, or current-state truth changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,8 @@ These are non-negotiable. Don't cross them without asking.
 
 1. **`requireApiAuth()` on every `/api/app/*` route.**
 2. **Hashed-token verification on every `/api/creed/*` and `/mcp` route.**
-3. **No personal info in source.** Email / handles / names go through
-   `lib/branding.ts` env vars.
+3. **No personal info in source.** Email and legal operator name go through
+   `lib/branding.ts` env vars. Public product links are constants in that file.
 4. **Marketing routes never read user state.** The root layout skips
    `loadCreedState` based on the `x-pathname` header set by `proxy.ts`.
    Don't reintroduce a fan-out without that gate.

--- a/apps/cloud/.env.example
+++ b/apps/cloud/.env.example
@@ -1,131 +1,90 @@
-# Creed environment variables.
+# Creed Cloud environment
 #
 # Copy this file to `.env.local` and fill in the values. `.env.local` is
-# gitignored — never commit real keys. Server-only secrets are read in
-# Node-runtime route handlers; `NEXT_PUBLIC_*` values are bundled into
-# client code and visible in the browser, so only put non-secret config
-# there.
+# gitignored. Never commit real keys. Server-only secrets are read in
+# Node-runtime route handlers. NEXT_PUBLIC_* values are bundled into client
+# code, so only put non-secret config there.
 
-# ─── Site identity ──────────────────────────────────────────────────────
-# Used to construct absolute URLs (OAuth redirects, Stripe success/cancel
-# URLs, sitemap entries). Set to your deployed origin in production; the
-# code falls back to http://localhost:3000 in dev when this is unset.
+# Site identity. Used for OAuth redirects, Stripe return URLs, and sitemap
+# entries. Set to the deployed origin in production. Falls back to
+# http://localhost:3000 in local development when unset.
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
-# ─── Private Cloud development (optional) ──────────────────────────────
-# Set private on hosted development deployments to hide public signup,
-# disable billing, and allow only the comma-separated tester emails below.
-# Leave public for normal local development. Delete this block when Cloud
-# launches publicly; public is also the code default when the variables vanish.
+# Private Cloud development. Set private on hosted development deployments to
+# hide public signup, disable billing, and allow only the comma-separated
+# tester emails below. Leave public for normal local development. Public is
+# also the code default when these variables are absent.
 CREED_CLOUD_ACCESS=public
 CREED_CLOUD_TESTER_EMAILS=
 
-# ─── Supabase ───────────────────────────────────────────────────────────
-# Public values come from Supabase Dashboard → Project Settings → API.
+# Supabase. Public values come from Project Settings > API.
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
-# Legacy alias for the same key — set one of the two, both are read.
+# Legacy alias for the same key. Set one of the two.
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
-# Server-only secret with admin privileges (webhook + edge writes). NEVER
-# expose to the browser. From Supabase Dashboard → Project Settings → API
-# under "service_role" (or the newer secret-key model — both names work).
+# Server-only secret with admin privileges. Never expose to the browser.
+# From Project Settings > API under service_role, or the newer secret key.
 SUPABASE_SECRET_KEY=
 # SUPABASE_SERVICE_ROLE_KEY=
 
-# ─── Stripe ─────────────────────────────────────────────────────────────
-# Test keys live at https://dashboard.stripe.com/test/apikeys. Swap for
-# `sk_live_…` + `pk_live_…` in production.
+# Stripe. Test keys live at https://dashboard.stripe.com/test/apikeys.
+# Swap for live keys in production.
 STRIPE_SECRET_KEY=sk_test_...
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 
-# Prices are NOT configured here. They resolve by Stripe lookup key at runtime
-# (see PRICE_LOOKUP_KEYS in lib/stripe.ts): creed_cloud_monthly and
-# creed_cloud_yearly.
-# Assign each lookup key to its price in the Stripe dashboard (Products → price
-# → Edit → Lookup key). No price ids or env vars needed - re-pointing a key in
-# Stripe takes effect without a redeploy.
+# Prices resolve by Stripe lookup key at runtime (creed_cloud_monthly and
+# creed_cloud_yearly). Assign each lookup key to its price in Stripe.
+# No price ids or env vars are needed.
 
-# Webhook signing secret. For local dev, run:
+# Webhook signing secret. For local dev:
 #   stripe listen --forward-to localhost:3000/api/stripe/webhook
-# and copy the `whsec_…` it prints. For production, create a webhook
-# endpoint in the Stripe Dashboard pointing at /api/stripe/webhook and
-# copy that endpoint's signing secret.
-# Subscribe it to checkout.session.completed, customer.subscription.updated,
-# customer.subscription.deleted, payment_intent.succeeded,
-# payment_intent.payment_failed, charge.refunded, refund.created,
-# refund.updated, refund.failed, charge.dispute.created,
+# For production, create a webhook at /api/stripe/webhook and copy that
+# endpoint's signing secret. Subscribe it to checkout.session.completed,
+# customer.subscription.updated, customer.subscription.deleted,
+# payment_intent.succeeded, payment_intent.payment_failed, charge.refunded,
+# refund.created, refund.updated, refund.failed, charge.dispute.created,
 # charge.dispute.updated, charge.dispute.closed,
 # charge.dispute.funds_reinstated, and charge.dispute.funds_withdrawn.
 STRIPE_WEBHOOK_SECRET=whsec_...
 
-# ─── Token / payload encryption ─────────────────────────────────────────
-# 32-byte base64 secret used to encrypt provider tokens at rest. Generate
-# with: openssl rand -base64 32
+# Encrypts provider tokens at rest. Generate with: openssl rand -base64 32
 CREED_ENCRYPTION_SECRET=
-# During key rotation, set this to the old secret until stored tokens have been
-# rewritten by normal use. New ciphertext always uses CREED_ENCRYPTION_SECRET.
+# During key rotation, set this to the old secret until stored tokens have
+# been rewritten by normal use. New ciphertext always uses
+# CREED_ENCRYPTION_SECRET.
 CREED_ENCRYPTION_SECRET_PREVIOUS=
 
-# Optional shared secret for detailed /api/health component diagnostics.
+# Shared with the status deployment so /api/health can return per-component
+# detail. Leave unset for a summary-only health response.
 CREED_HEALTH_SECRET=
 
-# ─── OpenRouter platform key (managed AI credits) ───────────────────────
-# Server-side OpenRouter key Creed runs first-party AI on for users on the
-# prepaid "credits" plan (the default). BYOK users bring their own key in
-# Settings and never touch this. Leave unset to disable credits mode: the app
-# still boots, but credits-mode AI calls return a friendly "temporarily
-# unavailable" until it is set. Create one at https://openrouter.ai/keys.
+# Server-side OpenRouter key for managed credits. BYOK users never touch this.
+# Leave unset to disable credits-mode AI until it is set.
 OPENROUTER_PLATFORM_KEY=
 
-# Model per AI feature, hidden from users and selected server-side. Each is an
-# OpenRouter model id; any unset one falls back to a built-in default.
-# Analysis defaults to Haiku; Tab and Panel default to a fast open-weights
-# model served by Groq / Cerebras (their routes request throughput routing).
-ANALYSIS_MODEL=
-TAB_MODEL=
-PANEL_MODEL=
-
-# ─── Transactional email (Resend) ───────────────────────────────────────
-# Used to send Shared Creed invite emails. RESEND_FROM_EMAIL must be an address on
-# a domain verified in Resend. Without these, invites still record but the
-# email send fails (surfaced to the inviter, and the invite can be resent).
+# Shared Creed invite email. RESEND_FROM_EMAIL must be on a domain verified
+# in Resend. Without these, invites still record but sending fails.
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=Creed <hello@creed.md>
 
-# ─── GitHub OAuth (version-control integration) ─────────────────────────
-# A single GitHub OAuth App backs both Personal and Shared
-# GitHub connections (sync a Creed to a repo). GitHub is NOT a sign-in
-# provider - this app is used purely for repo access.
-# Create an OAuth App at https://github.com/settings/developers and set its
-# "Authorization callback URL" to:  <your-site>/auth/github/callback
-# (e.g. http://localhost:3000/auth/github/callback for local dev; use a
-# separate app per environment, since an OAuth App has one callback host).
-# Leave blank to hide the "Connect GitHub" actions in settings.
+# GitHub OAuth for Personal and Shared repo connections. Not a sign-in
+# provider. Callback: <NEXT_PUBLIC_SITE_URL>/auth/github/callback
+# Leave blank to hide Connect GitHub in settings.
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 
-# ─── Branding / social links (optional) ─────────────────────────────────
-# These show up in the footer + contact CTAs. Leaving any blank hides
-# the corresponding link rather than rendering a dead one.
+# Shown on legal pages and in the footer. Leave blank to hide the address.
 NEXT_PUBLIC_CONTACT_EMAIL=hello@creed.md
 NEXT_PUBLIC_LEGAL_OPERATOR_NAME=Creed
-NEXT_PUBLIC_TWITTER_URL=https://x.com/yourhandle
-NEXT_PUBLIC_INSTAGRAM_URL=
-NEXT_PUBLIC_GITHUB_URL=https://github.com/hpbrn/creed
 
-# ─── Feedback widget (optional) ─────────────────────────────────────────
-# API key for the Median.co feedback receiver. Without it, the in-app
-# feedback form returns 503 with a friendly message.
+# Median.co feedback and public roadmap. Without it, in-app feedback returns
+# 503 and the roadmap page shows empty columns.
 MEDIAN_API_KEY=
 
-# ─── Build flags (optional) ─────────────────────────────────────────────
-# Production enforces CSP by default. Set this only for an emergency
-# Report-Only rollback, then remove it after the violation is fixed.
+# Optional production emergency switch. Production enforces CSP by default.
 # CREED_CSP_ENFORCE=0
 
-# Set ANALYZE=true to run @next/bundle-analyzer during the build.
+# Optional build diagnostics.
 # ANALYZE=true
-
-# Optional: surfaced in the system-status pill in the footer.
 # NEXT_PUBLIC_RELEASE_SHA=

--- a/apps/open/.env.example
+++ b/apps/open/.env.example
@@ -30,14 +30,12 @@ CREED_ENCRYPTION_SECRET_PREVIOUS=
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 
-# Optional: public repository and project links.
-NEXT_PUBLIC_GITHUB_URL=https://github.com/hpbrn/creed
+# Optional: contact address and legal operator shown in the app.
 NEXT_PUBLIC_CONTACT_EMAIL=
 NEXT_PUBLIC_LEGAL_OPERATOR_NAME=
-NEXT_PUBLIC_TWITTER_URL=
-NEXT_PUBLIC_INSTAGRAM_URL=
 
-# Optional: detailed health checks shared with a status deployment.
+# Optional: shared with a status.creed.md deployment so /api/health can return
+# per-component detail. Leave unset for a summary-only health response.
 CREED_HEALTH_SECRET=
 
 # Optional production emergency switch. Production enforces CSP by default.

--- a/apps/status/.env.example
+++ b/apps/status/.env.example
@@ -1,0 +1,26 @@
+# Creed Status environment
+#
+# Copy this file to `.env.local`. Values prefixed with NEXT_PUBLIC_ are exposed
+# to the browser. Every other value must remain server-only.
+
+# Origin to probe. Defaults to https://creed.md when unset.
+NEXT_PUBLIC_CREED_ORIGIN=https://creed.md
+
+# Must match CREED_HEALTH_SECRET on the Creed app being probed. Unlocks the
+# per-component breakdown from /api/health. Leave unset for coarser detail.
+CREED_HEALTH_SECRET=
+
+# Production snapshot store. Prefer Redis when both URL and token are set.
+# Otherwise BLOB_READ_WRITE_TOKEN stores one private aggregate document.
+# Local development uses an in-memory buffer when neither store is set.
+BLOB_READ_WRITE_TOKEN=
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
+# KV_REST_API_URL=
+# KV_REST_API_TOKEN=
+
+# Bearer secret required to hit /api/probe in production. Vercel Cron sends
+# CRON_SECRET. STATUS_PROBE_SECRET is an accepted alias. Local development
+# remains open when both are unset.
+CRON_SECRET=
+# STATUS_PROBE_SECRET=

--- a/apps/status/.gitignore
+++ b/apps/status/.gitignore
@@ -28,3 +28,4 @@ yarn-error.log*
 # TypeScript
 *.tsbuildinfo
 .env*
+!.env.example

--- a/packages/creed-app/app/globals.css
+++ b/packages/creed-app/app/globals.css
@@ -561,6 +561,10 @@
   font-size: inherit;
 }
 
+.creed-list .creed-list {
+  margin-top: 0.25rem;
+}
+
 .creed-list {
   margin: 0;
   /* Shared text column so bullets, checks, and numbers line up. */
@@ -1098,6 +1102,20 @@
 
 .ProseMirror a:hover {
   opacity: 0.82;
+}
+
+.ProseMirror u {
+  text-decoration: underline;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 0.18em;
+  text-decoration-color: var(--section-accent-bar, var(--creed-text-secondary));
+}
+
+.ProseMirror mark {
+  background: var(--section-accent-tint, rgba(210, 163, 91, 0.28));
+  color: inherit;
+  border-radius: 3px;
+  padding: 0.05em 0.18em;
 }
 
 [data-modifier-link-mode="true"] .ProseMirror a {

--- a/packages/creed-app/components/creed/extensions/tab-complete.ts
+++ b/packages/creed-app/components/creed/extensions/tab-complete.ts
@@ -431,7 +431,8 @@ export const TabComplete = Extension.create<TabCompleteOptions>({
             // outdents everywhere as usual.
             if (
               view.state.selection.$from.parentOffset === 0 &&
-              editor.can().sinkListItem("listItem")
+              (editor.can().sinkListItem("listItem") ||
+                editor.can().sinkListItem("taskItem"))
             ) {
               return false;
             }

--- a/packages/creed-app/components/creed/extensions/underline.ts
+++ b/packages/creed-app/components/creed/extensions/underline.ts
@@ -1,0 +1,30 @@
+import { Mark, mergeAttributes } from "@tiptap/core";
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    creedUnderline: {
+      toggleUnderline: () => ReturnType;
+    };
+  }
+}
+
+export const CreedUnderline = Mark.create({
+  name: "underline",
+
+  parseHTML() {
+    return [{ tag: "u" }, { style: "text-decoration=underline" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["u", mergeAttributes(HTMLAttributes), 0];
+  },
+
+  addCommands() {
+    return {
+      toggleUnderline:
+        () =>
+        ({ commands }) =>
+          commands.toggleMark(this.name),
+    };
+  },
+});

--- a/packages/creed-app/components/creed/inline-proposal-diff.tsx
+++ b/packages/creed-app/components/creed/inline-proposal-diff.tsx
@@ -18,6 +18,9 @@ import {
 
 const expandTransition = { duration: 0.28, ease: [0.22, 1, 0.36, 1] as const };
 
+const DIFF_BODY_CLASS =
+  "creed-scrollbar creed-diff-block max-h-[min(40vh,20rem)] overflow-y-auto py-3";
+
 // The 20px attribution glyph on a proposal card: a member's real profile
 // picture (squircle, same footprint as the agent glyph) when they typed the
 // edit by hand, or the connected agent's glyph when an agent proposed it.
@@ -301,7 +304,7 @@ export function InlineProposalDiff({
 
       <ExpandRegion open={expanded}>
         <div className="border-t border-[var(--creed-border)]" />
-        <div className="creed-diff-block py-3">
+        <div className={DIFF_BODY_CLASS}>
           <CreedDiffView diff={diff} />
         </div>
         {proposal.reason ? (
@@ -412,7 +415,7 @@ export function InlineNewSectionProposal({
       </div>
       <ExpandRegion open={expanded}>
         <div className="border-t border-[#10b981]/20" />
-        <div className="creed-diff-block py-3 text-[14px] leading-7 text-[var(--creed-text-primary)]">
+        <div className={cn(DIFF_BODY_CLASS, "text-[14px] leading-7 text-[var(--creed-text-primary)]")}>
           <CreedDiffView diff={diff} />
         </div>
         {proposal.reason ? (
@@ -585,7 +588,7 @@ export function InlineMetaProposal({
         {/* Typography matched to the new-section card: 14px / leading-7
             so the two card bodies read at the same visual weight. */}
         {isDelete ? (
-          <div className="creed-diff-block py-3 text-[14px] leading-7 text-[var(--creed-text-primary)]">
+          <div className={cn(DIFF_BODY_CLASS, "text-[14px] leading-7 text-[var(--creed-text-primary)]")}>
             <CreedDiffView diff={deleteDiff!} />
           </div>
         ) : (

--- a/packages/creed-app/components/creed/rich-text-editor.tsx
+++ b/packages/creed-app/components/creed/rich-text-editor.tsx
@@ -12,6 +12,7 @@ import {
 import { createPortal } from "react-dom";
 import { Extension, type Editor, type Range } from "@tiptap/core";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import Highlight from "@tiptap/extension-highlight";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
@@ -33,6 +34,7 @@ import {
   Heading2,
   Heading3,
   Heading4,
+  Highlighter,
   Italic,
   Link2,
   List,
@@ -46,14 +48,20 @@ import {
   Pilcrow,
   PlusSquare,
   Strikethrough,
+  Underline,
 } from "lucide-react";
 import {
   InlineTagMark,
   type SectionTagTarget,
 } from "@/components/creed/extensions/inline-tag";
 import { CreedTable } from "@/components/creed/extensions/creed-table";
+import { CreedUnderline } from "@/components/creed/extensions/underline";
 import { TabComplete } from "@/components/creed/extensions/tab-complete";
-import { markdownToRichHtml } from "@creed/core/rich-text";
+import {
+  clipboardPlainTextAsMarkdown,
+  markdownToRichHtml,
+  sanitizeRichTextHtml,
+} from "@creed/core/rich-text";
 import {
   SECTION_REFERENCE_PICKER_GAP,
   SECTION_REFERENCE_PICKER_MAX_ROWS,
@@ -1033,15 +1041,22 @@ function RichTextEditorImpl({
         codeBlock: false,
         link: {
           openOnClick: false,
+          autolink: true,
+          linkOnPaste: true,
+          protocols: ["http", "https", "mailto"],
         },
       }),
+      Highlight.configure({
+        multicolor: false,
+      }),
+      CreedUnderline,
       TaskList.configure({
         HTMLAttributes: {
           class: "creed-list creed-list-task",
         },
       }),
       TaskItem.configure({
-        nested: false,
+        nested: true,
         HTMLAttributes: {
           class: "creed-list-item",
         },
@@ -1107,6 +1122,21 @@ function RichTextEditorImpl({
 
         event.preventDefault();
         window.open(link.href, "_blank", "noopener,noreferrer");
+        return true;
+      },
+      handlePaste: (view, event) => {
+        if (!view.editable) return false;
+        const editor = editorRef.current;
+        if (!editor) return false;
+        const clipboard = event.clipboardData;
+        if (!clipboard) return false;
+        const plain = clipboard.getData("text/plain");
+        const html = clipboard.getData("text/html");
+        if (!clipboardPlainTextAsMarkdown(plain, html)) return false;
+        const converted = sanitizeRichTextHtml(markdownToRichHtml(plain));
+        if (!converted) return false;
+        event.preventDefault();
+        editor.chain().focus().insertContent(converted).run();
         return true;
       },
       handleKeyDown: (view, event) => {
@@ -1678,6 +1708,19 @@ function RichTextEditorImpl({
                     <Italic className="h-3.5 w-3.5" />
                   </ToolbarButton>
                   <ToolbarButton
+                    active={editor.isActive("underline")}
+                    disabled={
+                      editor.isActive("code") ||
+                      !editor.can().chain().focus().toggleUnderline().run()
+                    }
+                    onClick={() =>
+                      editor.chain().focus().toggleUnderline().run()
+                    }
+                    label="Underline"
+                  >
+                    <Underline className="h-3.5 w-3.5" />
+                  </ToolbarButton>
+                  <ToolbarButton
                     active={editor.isActive("strike")}
                     disabled={
                       editor.isActive("code") ||
@@ -1687,6 +1730,19 @@ function RichTextEditorImpl({
                     label="Strikethrough"
                   >
                     <Strikethrough className="h-3.5 w-3.5" />
+                  </ToolbarButton>
+                  <ToolbarButton
+                    active={editor.isActive("highlight")}
+                    disabled={
+                      editor.isActive("code") ||
+                      !editor.can().chain().focus().toggleHighlight().run()
+                    }
+                    onClick={() =>
+                      editor.chain().focus().toggleHighlight().run()
+                    }
+                    label="Highlight"
+                  >
+                    <Highlighter className="h-3.5 w-3.5" />
                   </ToolbarButton>
                   <ToolbarButton
                     active={editor.isActive("code")}

--- a/packages/creed-app/lib/ai/tab.ts
+++ b/packages/creed-app/lib/ai/tab.ts
@@ -89,8 +89,8 @@ export function buildTabSystemPrompt(): string {
     "- Output only the continuation. Never add commentary or wrap the whole reply in quotes.",
     "- Begin exactly where the text stops. Never repeat or re-type anything already written before the cursor. Include a leading space when the text before the cursor ends mid-sentence without one. If the cursor sits mid-word, finish that word first.",
     "- Complete one useful unit. Usually finish the current sentence and stop. For an empty section or empty block, you may add one compact structural block when it fits the surrounding section.",
-    "- You can use every native Creed block through Markdown: ## to #### headings, - bullets, numbered lists, > callouts, fenced code blocks with a language, --- dividers, inline emphasis, links, and #section-id references.",
-    "- Choose structure by meaning and local style. Continue an existing list with the same marker. Use a callout only for a real warning or governing rule, code only for literal code or commands, headings only to open a distinct group, and dividers only between substantial groups. Plain prose is the default.",
+    "- You can use every native Creed block through Markdown: ## to #### headings, - bullets (including 2-space nested lists), numbered lists, > callouts, fenced code blocks with a language, --- dividers, inline emphasis, links, and #section-id references.",
+    "- Choose structure by meaning and local style. Continue an existing list with the same marker. Indent two spaces to nest. Use a callout only for a real warning or governing rule, code only for literal code or commands, headings only to open a distinct group, and dividers only between substantial groups. Plain prose is the default.",
     "- Use #section-id only for a real section listed in the reference catalog. Never invent tags or use hashtags as generic labels.",
     "- Never start a new block in the middle of a sentence or non-empty text block. Rich blocks belong only at an empty block boundary.",
   ].join("\n");

--- a/packages/creed-app/lib/branding.ts
+++ b/packages/creed-app/lib/branding.ts
@@ -1,16 +1,6 @@
-// Branding + contact constants pulled from environment variables so the
-// open-source codebase doesn't ship with personal identifiers baked in.
-// Set these in `.env.local` (or your deployment env) when running a fork:
-//
-//   NEXT_PUBLIC_CONTACT_EMAIL   = address shown in legal pages + footer
-//   NEXT_PUBLIC_LEGAL_OPERATOR_NAME = legal operator shown in hosted terms
-//   NEXT_PUBLIC_TWITTER_URL     = absolute URL of the project's X / Twitter profile
-//   NEXT_PUBLIC_INSTAGRAM_URL   = absolute URL of the project's Instagram profile
-//   NEXT_PUBLIC_GITHUB_URL      = absolute URL of the project's GitHub org / repo
-//   NEXT_PUBLIC_HPBRN_URL       = absolute URL of the hpbrn site/profile
-//
-// Anything left unset falls back to a sensible no-op (an empty string for the
-// email, `null` for social links so the chrome can hide the icon entirely).
+// Contact and legal operator stay in env so personal identity is not baked
+// into the public repo. Public product links are constants here. An empty
+// social URL hides the corresponding footer icon.
 
 export const CONTACT_EMAIL =
   process.env.NEXT_PUBLIC_CONTACT_EMAIL?.trim() || "";
@@ -19,16 +9,7 @@ export const LEGAL_OPERATOR_NAME =
 
 export const CONTACT_MAILTO = `mailto:${CONTACT_EMAIL}`;
 
-// Default social URLs surface on the deployed site without needing env
-// vars set. Forks can override via NEXT_PUBLIC_*_URL or set the env var
-// to an empty string to hide the icon entirely.
-export const TWITTER_URL =
-  process.env.NEXT_PUBLIC_TWITTER_URL?.trim() || "";
-export const INSTAGRAM_URL =
-  process.env.NEXT_PUBLIC_INSTAGRAM_URL?.trim() || "";
-export const GITHUB_URL =
-  process.env.NEXT_PUBLIC_GITHUB_URL?.trim() || "https://github.com/hpbrn/creed";
-export const HPBRN_URL =
-  process.env.NEXT_PUBLIC_HPBRN_URL?.trim() || "";
-
+export const GITHUB_URL = "https://github.com/hpbrn/creed";
 export const DISCORD_URL = "https://discord.gg/4AxX8AbwH8";
+export const TWITTER_URL = "https://x.com/connorhpbrn";
+export const INSTAGRAM_URL = "https://www.instagram.com/connorhpbrn";

--- a/packages/creed-app/tests/github-roundtrip.test.ts
+++ b/packages/creed-app/tests/github-roundtrip.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { sectionToMarkdown } from "@creed/core/creed-data";
 import { parseCreedMarkdown } from "@creed/core/creed-markdown";
-import { markdownToRichHtml } from "@creed/core/rich-text";
+import { markdownToRichHtml, clipboardPlainTextAsMarkdown } from "@creed/core/rich-text";
 import type { CreedSection } from "@creed/core/creed-data";
 
 // Round-trip the push → pull pipeline. Each test pushes a section through
@@ -163,6 +163,31 @@ test("inline bold and italic round-trip", () => {
   assert.ok(result.includes("<em>italic</em>"), `missing italic: ${result}`);
 });
 
+test("underline and highlight round-trip", () => {
+  const result = roundtripContent(
+    "<p>This is <u>underlined</u> and <mark>highlighted</mark>.</p>",
+  );
+  assert.match(result, /<u>underlined<\/u>/);
+  assert.match(result, /<mark>highlighted<\/mark>/);
+});
+
+test("bare and angle URLs become links", () => {
+  const bare = markdownToRichHtml("See https://creed.md for this.");
+  assert.match(bare, /<a href="https:\/\/creed.md"/);
+  assert.match(bare, />https:\/\/creed.md</);
+  const angled = markdownToRichHtml("See <https://creed.md> for this.");
+  assert.match(angled, /<a href="https:\/\/creed.md"/);
+  const labeled = markdownToRichHtml("See [Creed](https://creed.md).");
+  assert.match(labeled, /<a href="https:\/\/creed.md"/);
+  assert.match(labeled, />Creed</);
+  assert.doesNotMatch(labeled, />https:\/\/creed.md</);
+});
+
+test("javascript URLs are not autolinked", () => {
+  const result = markdownToRichHtml("Run javascript:alert(1) please.");
+  assert.doesNotMatch(result, /<a /);
+});
+
 test("multi-paragraph round-trip yields multiple paragraphs", () => {
   const result = roundtripContent("<p>First.</p><p>Second.</p><p>Third.</p>");
   const paragraphs = result.match(/<p>/g);
@@ -175,4 +200,60 @@ test("does not collapse paragraphs into bullet list", () => {
   );
   assert.ok(!result.includes("<ul"), `unexpected list in: ${result}`);
   assert.ok(!result.includes("<li>"), `unexpected list item in: ${result}`);
+});
+
+test("nested bullet markdown becomes nested lists", () => {
+  const result = markdownToRichHtml("- Work\n  - Linear\n  - Figma");
+  assert.match(result, /Work<ul class="creed-list creed-list-bullet">/);
+  assert.match(result, /Linear/);
+  assert.match(result, /Figma/);
+  const lists = result.match(/<ul class="creed-list creed-list-bullet">/g);
+  assert.equal(lists?.length, 2, `expected two bullet lists, got: ${result}`);
+});
+
+test("nested list round-trip keeps child items", () => {
+  const editor =
+    `<ul class="creed-list creed-list-bullet">` +
+    `<li class="creed-list-item">Work` +
+    `<ul class="creed-list creed-list-bullet">` +
+    `<li class="creed-list-item">Linear</li>` +
+    `<li class="creed-list-item">Figma</li>` +
+    `</ul>` +
+    `</li>` +
+    `</ul>`;
+  const result = roundtripContent(editor);
+  assert.match(result, /Work/);
+  assert.match(result, /Linear/);
+  assert.match(result, /Figma/);
+  const lists = result.match(/<ul class="creed-list creed-list-bullet">/g);
+  assert.equal(lists?.length, 2, `expected nested ul to survive, got: ${result}`);
+});
+
+test("nested numbered list under a bullet survives markdown", () => {
+  const result = markdownToRichHtml("- Steps\n  1. First\n  2. Second");
+  assert.match(result, /<ol class="creed-list creed-list-ordered">/);
+  assert.match(result, /First/);
+  assert.match(result, /Second/);
+});
+
+test("nested checklist markdown stays a task list", () => {
+  const result = markdownToRichHtml("- [ ] Parent\n  - [x] Child");
+  assert.match(result, /data-type="taskList"/);
+  assert.match(result, /data-checked="false"/);
+  assert.match(result, /data-checked="true"/);
+  assert.match(result, /Parent/);
+  assert.match(result, /Child/);
+  const lists = result.match(/data-type="taskList"/g);
+  assert.equal(lists?.length, 2, `expected nested task lists, got: ${result}`);
+});
+
+test("clipboard markdown is detected without eating plain prose or URLs", () => {
+  assert.equal(clipboardPlainTextAsMarkdown("- Work\n  - Linear"), true);
+  assert.equal(clipboardPlainTextAsMarkdown("**Connor**"), true);
+  assert.equal(clipboardPlainTextAsMarkdown("https://creed.md"), false);
+  assert.equal(clipboardPlainTextAsMarkdown("Just a sentence."), false);
+  assert.equal(
+    clipboardPlainTextAsMarkdown("- Work", "<ul><li>Work</li></ul>"),
+    false,
+  );
 });

--- a/packages/creed-core/creed-data.ts
+++ b/packages/creed-core/creed-data.ts
@@ -1186,6 +1186,7 @@ export const collaborationRules: HiddenInstructionContract = {
 //   <h3>...</h3>                                → #### ...
 //   <h4>...</h4>                                → ##### ...
 //   <ul><li>...</li></ul>                       → - ...
+//   nested <ul>/<ol> inside <li>                → two-space indented list
 //   <ul data-type="taskList">...                → - [ ] / - [x]
 //   <ol><li>...</li></ol>                       → 1. ...
 //   <table>...</table>                          → GFM pipe table
@@ -1276,27 +1277,8 @@ export function richTextToMarkdown(content: string) {
     },
   );
 
-  // Checklists before generic `<ul>` so `- [x]` does not flatten to `-`.
-  text = text.replace(/<ul\b([^>]*)>([\s\S]*?)<\/ul>/g, (match, attrs: string, body: string) => {
-    const isTask =
-      /data-type\s*=\s*(["'])taskList\1/i.test(attrs) ||
-      /\bcreed-list-task\b/.test(attrs);
-    if (!isTask) return match;
-
-    const items = Array.from(body.matchAll(/<li\b([^>]*)>([\s\S]*?)<\/li>/g))
-      .map((itemMatch) => {
-        const liAttrs = itemMatch[1];
-        const checkedMatch = liAttrs.match(
-          /data-checked\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i,
-        );
-        const raw = (checkedMatch?.[1] ?? checkedMatch?.[2] ?? checkedMatch?.[3] ?? "").toLowerCase();
-        const checked = raw === "true" || raw === "checked";
-        const label = stripTags(itemMatch[2]).trim();
-        return `- [${checked ? "x" : " "}] ${label}`.trimEnd();
-      })
-      .filter((line) => /^-\s+\[[ x]\]/.test(line));
-    return items.length ? `\n${items.join("\n")}\n` : "";
-  });
+  // Lists, including nested bullets, numbers, and checklists.
+  text = convertHtmlLists(text);
 
   // GFM tables. Run before remaining tag stripping so cell markup can still
   // use the inline conversions above. First-row `th` becomes a GFM header.
@@ -1330,22 +1312,6 @@ export function richTextToMarkdown(content: string) {
     return `\n${HEADERLESS_TABLE_MARK}\n${[emptyHeader, separator, ...parsed.map(format)].join("\n")}\n`;
   });
 
-  // Numbered lists.
-  text = text.replace(/<ol[^>]*>([\s\S]*?)<\/ol>/g, (_match, body: string) => {
-    const items = Array.from(body.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/g))
-      .map((match, index) => `${index + 1}. ${stripTags(match[1]).trim()}`)
-      .filter((line) => line.replace(/^\d+\.\s*/, "").length > 0);
-    return items.length ? `\n${items.join("\n")}\n` : "";
-  });
-
-  // Bullet lists.
-  text = text.replace(/<ul[^>]*>([\s\S]*?)<\/ul>/g, (_match, body: string) => {
-    const items = Array.from(body.matchAll(/<li[^>]*>([\s\S]*?)<\/li>/g))
-      .map((match) => `- ${stripTags(match[1]).trim()}`)
-      .filter((line) => line.length > 2);
-    return items.length ? `\n${items.join("\n")}\n` : "";
-  });
-
   // Paragraphs - drop empty paragraphs entirely so we don't emit blank lines
   // for `<p></p>` placeholders that the editor sometimes leaves behind.
   text = text.replace(/<p[^>]*>([\s\S]*?)<\/p>/g, (_match, body: string) => {
@@ -1376,6 +1342,154 @@ export function sectionBodyMarkdown(section: CreedSection): string {
   return sectionToMarkdown(section)
     .replace(/^##\s.*(?:\n+|$)/, "")
     .trim();
+}
+
+function findHtmlOpenTag(
+  html: string,
+  from: number,
+  tag: string,
+): { index: number; attrs: string; contentStart: number } | null {
+  const pattern = new RegExp(`<${tag}\\b([^>]*)>`, "gi");
+  pattern.lastIndex = from;
+  const match = pattern.exec(html);
+  if (!match) return null;
+  return {
+    index: match.index,
+    attrs: match[1] ?? "",
+    contentStart: match.index + match[0].length,
+  };
+}
+
+function findMatchingCloseTag(html: string, tag: string, contentStart: number) {
+  const openPattern = new RegExp(`<${tag}\\b[^>]*>`, "gi");
+  const closePattern = new RegExp(`</${tag}\\s*>`, "gi");
+  let depth = 1;
+  let cursor = contentStart;
+  while (cursor < html.length && depth > 0) {
+    openPattern.lastIndex = cursor;
+    closePattern.lastIndex = cursor;
+    const open = openPattern.exec(html);
+    const close = closePattern.exec(html);
+    if (!close) return html.length;
+    if (open && open.index < close.index) {
+      depth += 1;
+      cursor = open.index + open[0].length;
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) return close.index;
+    cursor = close.index + close[0].length;
+  }
+  return html.length;
+}
+
+function findNextHtmlList(
+  html: string,
+  from: number,
+): { tag: "ul" | "ol"; index: number; attrs: string; contentStart: number } | null {
+  const ul = findHtmlOpenTag(html, from, "ul");
+  const ol = findHtmlOpenTag(html, from, "ol");
+  if (ul && (!ol || ul.index <= ol.index)) {
+    return { tag: "ul", ...ul };
+  }
+  if (ol) return { tag: "ol", ...ol };
+  return null;
+}
+
+function splitTopLevelListItems(body: string) {
+  const items: Array<{ attrs: string; inner: string }> = [];
+  let cursor = 0;
+  while (cursor < body.length) {
+    const open = findHtmlOpenTag(body, cursor, "li");
+    if (!open) break;
+    const close = findMatchingCloseTag(body, "li", open.contentStart);
+    items.push({
+      attrs: open.attrs,
+      inner: body.slice(open.contentStart, close),
+    });
+    const closeTag = body.slice(close).match(/^<\/li\s*>/i);
+    cursor = close + (closeTag ? closeTag[0].length : 0);
+    if (cursor <= open.index) break;
+  }
+  return items;
+}
+
+function isTaskListAttrs(attrs: string) {
+  return (
+    /data-type\s*=\s*(["'])taskList\1/i.test(attrs) ||
+    /\bcreed-list-task\b/.test(attrs)
+  );
+}
+
+function serializeHtmlList(
+  html: string,
+  open: { tag: "ul" | "ol"; index: number; attrs: string; contentStart: number },
+  indent: string,
+): { markdown: string; end: number } {
+  const close = findMatchingCloseTag(html, open.tag, open.contentStart);
+  const closeTag = html.slice(close).match(new RegExp(`^</${open.tag}\\s*>`, "i"));
+  const end = close + (closeTag ? closeTag[0].length : 0);
+  const isTask = open.tag === "ul" && isTaskListAttrs(open.attrs);
+  const items = splitTopLevelListItems(html.slice(open.contentStart, close));
+  const lines: string[] = [];
+  items.forEach((item, index) => {
+    const checkedMatch = item.attrs.match(
+      /data-checked\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i,
+    );
+    const raw = (
+      checkedMatch?.[1] ??
+      checkedMatch?.[2] ??
+      checkedMatch?.[3] ??
+      ""
+    ).toLowerCase();
+    const checked = raw === "true" || raw === "checked";
+    const marker = isTask
+      ? `- [${checked ? "x" : " "}] `
+      : open.tag === "ol"
+        ? `${index + 1}. `
+        : `- `;
+    lines.push(...serializeHtmlListItem(item.inner, indent, marker));
+  });
+  const markdown = lines.length ? `${lines.join("\n")}` : "";
+  return { markdown, end };
+}
+
+function serializeHtmlListItem(inner: string, indent: string, marker: string) {
+  const nested: string[] = [];
+  let rest = "";
+  let cursor = 0;
+  while (cursor < inner.length) {
+    const nestedList = findNextHtmlList(inner, cursor);
+    if (!nestedList) {
+      rest += inner.slice(cursor);
+      break;
+    }
+    rest += inner.slice(cursor, nestedList.index);
+    const serialized = serializeHtmlList(inner, nestedList, `${indent}  `);
+    if (serialized.markdown) nested.push(serialized.markdown);
+    cursor = serialized.end;
+  }
+  const text = stripTags(rest).trim().replace(/\n+/g, " ");
+  if (!text && nested.length === 0 && !marker.includes("[")) return [];
+  const head = `${indent}${marker}${text}`.trimEnd();
+  return nested.length > 0 ? [head, ...nested] : [head];
+}
+
+function convertHtmlLists(html: string) {
+  let result = "";
+  let cursor = 0;
+  while (cursor < html.length) {
+    const open = findNextHtmlList(html, cursor);
+    if (!open) {
+      result += html.slice(cursor);
+      break;
+    }
+    result += html.slice(cursor, open.index);
+    const serialized = serializeHtmlList(html, open, "");
+    result += serialized.markdown ? `\n${serialized.markdown}\n` : "";
+    cursor = serialized.end;
+  }
+  return result;
 }
 
 function stripTags(value: string) {
@@ -1756,15 +1870,15 @@ export function buildHiddenAgentGuidanceMarkdown(options?: {
       "  When: any section over a few short lines. Always group related rules under a heading instead of leaving them as a flat list.",
       "",
       "**Bullet lists** - unordered.",
-      "  Syntax: `- item` (or `* item`) on its own line, multiple items consecutive.",
+      "  Syntax: `- item` (or `* item`) on its own line, multiple items consecutive. Nest with two spaces before the marker.",
       "  When: short lists where order doesn't matter. Three items minimum or it should be a paragraph.",
       "",
       "**Numbered lists** - ordered or sequential.",
-      "  Syntax: `1. step` `2. step` `3. step` - Creed re-numbers automatically so you can use `1.` for every item if you prefer.",
+      "  Syntax: `1. step` `2. step` `3. step` - Creed re-numbers automatically so you can use `1.` for every item if you prefer. Nest with two spaces before the number.",
       "  When: order matters. Steps in a routine. Priorities ranked. Days of the week. Anything where 'first then second' is part of the meaning.",
       "",
       "**Checklists** - binary or completable items.",
-      "  Syntax: `- [ ] item` (open) or `- [x] item` (done) on its own line, multiple items consecutive.",
+      "  Syntax: `- [ ] item` (open) or `- [x] item` (done) on its own line, multiple items consecutive. Nest with two spaces, same as other lists.",
       "  When: a durable yes/no or done/not-done fact that belongs in the file. Standing commitments, recurring checks, or a small set of outcomes.",
       "  Don't: turn the Creed into a daily todo list. If it would go stale in a week, it does not belong here.",
       "",

--- a/packages/creed-core/rich-text.ts
+++ b/packages/creed-core/rich-text.ts
@@ -81,6 +81,40 @@ function withInlineCode(rawText: string, render: (rest: string) => string) {
   return out;
 }
 
+function stashAutolink(placeholders: string[], href: string, label: string) {
+  const token = `%%CREEDAUTOLINK${placeholders.length}%%`;
+  placeholders.push(
+    `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`,
+  );
+  return token;
+}
+
+// Angle-bracket and bare http(s) URLs. Stashed before escaping so
+// `<https://...>` is not turned into `&lt;https://...&gt;`, and so
+// `[label](https://...)` keeps its markdown link form (the URL sits
+// after `(` rather than whitespace).
+function withAutolinks(rawText: string, render: (rest: string) => string) {
+  const placeholders: string[] = [];
+  const withoutAngle = rawText.replace(
+    /<(https?:\/\/[^>\s]+)>/gi,
+    (_match, href: string) => stashAutolink(placeholders, href, href),
+  );
+  const stashed = withoutAngle.replace(
+    /(^|\s)(https?:\/\/[^\s<]+)/gi,
+    (_match, lead: string, url: string) => {
+      const trimmed = url.replace(/[.,;:!?)]+$/g, "");
+      const trail = url.slice(trimmed.length);
+      if (!/^https?:\/\//i.test(trimmed)) return `${lead}${url}`;
+      return `${lead}${stashAutolink(placeholders, trimmed, trimmed)}${trail}`;
+    },
+  );
+  let out = render(stashed);
+  placeholders.forEach((html, index) => {
+    out = out.replace(`%%CREEDAUTOLINK${index}%%`, html);
+  });
+  return out;
+}
+
 // Markdown links (`[text](url)`) - converted to anchor tags with the URL
 // HTML-escaped to keep this safe from injection through user-controlled
 // markdown. We deliberately restrict URLs to http(s) / mailto schemes and
@@ -106,17 +140,96 @@ function applyInlineExtras(escapedText: string) {
 }
 
 function inline(text: string) {
-  return withInlineCode(text, (stashed) => {
-    const escaped = escapeHtml(stashed);
-    return applyInlineExtras(
-      applyInlineEmphasis(applyInlineLinks(applyInlineTagMarks(escaped)))
-    );
-  });
+  return withInlineCode(text, (noCode) =>
+    withAutolinks(noCode, (stashed) => {
+      const escaped = escapeHtml(stashed);
+      return applyInlineExtras(
+        applyInlineEmphasis(applyInlineLinks(applyInlineTagMarks(escaped))),
+      );
+    }),
+  );
 }
 
 function paragraphize(lines: string[]) {
   const text = lines.join(" ").trim();
   return text ? `<p>${inline(text)}</p>` : "";
+}
+
+type MarkdownListKind = "ul" | "ol" | "task";
+type MarkdownListItem = {
+  indent: number;
+  kind: MarkdownListKind;
+  checked: boolean;
+  text: string;
+};
+
+function parseMarkdownListLine(line: string): MarkdownListItem | null {
+  const match = line.match(/^([ \t]*)([-*]|\d+\.)[ \t]+(.*)$/);
+  if (!match) return null;
+  const indent = match[1].replace(/\t/g, "  ").length;
+  const marker = match[2];
+  const rest = match[3];
+  if (marker === "-" || marker === "*") {
+    const task = rest.match(/^\[([ xX])\](?:[ \t]+(.*))?$/);
+    if (task) {
+      return {
+        indent,
+        kind: "task",
+        checked: task[1].toLowerCase() === "x",
+        text: task[2] ?? "",
+      };
+    }
+    return { indent, kind: "ul", checked: false, text: rest };
+  }
+  return { indent, kind: "ol", checked: false, text: rest };
+}
+
+function wrapMarkdownList(kind: MarkdownListKind, itemsHtml: string) {
+  if (kind === "task") {
+    return `<ul class="creed-list creed-list-task" data-type="taskList">${itemsHtml}</ul>`;
+  }
+  const tag = kind === "ol" ? "ol" : "ul";
+  const listClass =
+    kind === "ol" ? "creed-list creed-list-ordered" : "creed-list creed-list-bullet";
+  return `<${tag} class="${listClass}">${itemsHtml}</${tag}>`;
+}
+
+function wrapMarkdownListItem(item: MarkdownListItem, nestedHtml: string) {
+  if (item.kind === "task") {
+    return `<li class="creed-list-item" data-type="taskItem" data-checked="${item.checked}"><p>${inline(item.text)}</p>${nestedHtml}</li>`;
+  }
+  return `<li class="creed-list-item">${inline(item.text)}${nestedHtml}</li>`;
+}
+
+function renderMarkdownListForest(items: MarkdownListItem[]): string {
+  if (items.length === 0) return "";
+  const base = items[0].indent;
+  let html = "";
+  let index = 0;
+  while (index < items.length) {
+    const kind = items[index].kind;
+    const groupHtml: string[] = [];
+    while (
+      index < items.length &&
+      items[index].indent === base &&
+      items[index].kind === kind
+    ) {
+      const item = items[index];
+      index += 1;
+      const childStart = index;
+      while (index < items.length && items[index].indent > base) {
+        index += 1;
+      }
+      groupHtml.push(
+        wrapMarkdownListItem(
+          item,
+          renderMarkdownListForest(items.slice(childStart, index)),
+        ),
+      );
+    }
+    html += wrapMarkdownList(kind, groupHtml.join(""));
+  }
+  return html;
 }
 
 function isPipeRow(line: string) {
@@ -168,8 +281,7 @@ export function markdownToRichHtml(markdown: string) {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const blocks: string[] = [];
   let paragraphBuffer: string[] = [];
-  let listMode: "ul" | "ol" | "task" | null = null;
-  let listItems: Array<{ text: string; checked: boolean }> = [];
+  let listItems: MarkdownListItem[] = [];
   let quoteLines: string[] = [];
   let codeLines: string[] = [];
   let tableRows: string[] | null = null;
@@ -184,27 +296,9 @@ export function markdownToRichHtml(markdown: string) {
   }
 
   function flushList() {
-    if (listMode && listItems.length > 0) {
-      if (listMode === "task") {
-        blocks.push(
-          `<ul class="creed-list creed-list-task" data-type="taskList">${listItems
-            .map(
-              (item) =>
-                `<li class="creed-list-item" data-type="taskItem" data-checked="${item.checked}"><p>${inline(item.text)}</p></li>`,
-            )
-            .join("")}</ul>`,
-        );
-      } else {
-        const listClass =
-          listMode === "ul" ? "creed-list creed-list-bullet" : "creed-list creed-list-ordered";
-        blocks.push(
-          `<${listMode} class="${listClass}">${listItems
-            .map((item) => `<li class="creed-list-item">${inline(item.text)}</li>`)
-            .join("")}</${listMode}>`,
-        );
-      }
+    if (listItems.length > 0) {
+      blocks.push(renderMarkdownListForest(listItems));
     }
-    listMode = null;
     listItems = [];
   }
 
@@ -358,44 +452,12 @@ export function markdownToRichHtml(markdown: string) {
       continue;
     }
 
-    // GFM checklists must win over bullets. `- [ ] item` is otherwise a
-    // normal list item whose text starts with `[ ]`.
-    const task = trimmed.match(/^[-*]\s+\[([ xX])\](?:\s+(.*))?$/);
-    if (task) {
+    // Keep leading whitespace so nested markers can indent under a parent.
+    const listLine = parseMarkdownListLine(line);
+    if (listLine) {
       flushParagraph();
       flushQuote();
-      if (listMode && listMode !== "task") {
-        flushList();
-      }
-      listMode = "task";
-      listItems.push({
-        text: task[2] ?? "",
-        checked: task[1].toLowerCase() === "x",
-      });
-      continue;
-    }
-
-    const bullet = trimmed.match(/^[-*]\s+(.*)$/);
-    if (bullet) {
-      flushParagraph();
-      flushQuote();
-      if (listMode && listMode !== "ul") {
-        flushList();
-      }
-      listMode = "ul";
-      listItems.push({ text: bullet[1], checked: false });
-      continue;
-    }
-
-    const numbered = trimmed.match(/^\d+\.\s+(.*)$/);
-    if (numbered) {
-      flushParagraph();
-      flushQuote();
-      if (listMode && listMode !== "ol") {
-        flushList();
-      }
-      listMode = "ol";
-      listItems.push({ text: numbered[1], checked: false });
+      listItems.push(listLine);
       continue;
     }
 
@@ -535,4 +597,39 @@ export function normalizeRichTextInput(input: { contentHtml?: string; contentMar
   }
 
   return "";
+}
+
+const MARKDOWN_BLOCK_LINE =
+  /^(?:#{2,4}\s+\S|```|>\s?\S|[-*]\s+\S|\d+\.\s+\S|\|.+\||([-*_])\1{2,})$/;
+
+export function looksLikeMarkdown(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (/^https?:\/\/\S+$/i.test(trimmed)) return false;
+
+  for (const raw of trimmed.split("\n")) {
+    const line = raw.trimEnd();
+    const t = line.trim();
+    if (MARKDOWN_BLOCK_LINE.test(t)) return true;
+    if (/^[ \t]+(?:[-*]\s+\S|\d+\.\s+\S)/.test(line)) return true;
+  }
+
+  if (/\[[^\]]+\]\((?:https?:|mailto:|\/|#)[^)\s]+\)/.test(trimmed)) return true;
+  return /(\*\*[^*\n]+?\*\*|==[^=\n]+?==|~~[^~\n]+?~~|__[^_\n]+?__)/.test(
+    trimmed,
+  );
+}
+
+// Prefer Tiptap's HTML paste when the clipboard already carries lists,
+// headings, or other blocks. Convert plain text only when it looks like
+// markdown the user copied from an agent or a .md file.
+export function clipboardPlainTextAsMarkdown(
+  plain: string,
+  html?: string | null,
+) {
+  if (!looksLikeMarkdown(plain)) return false;
+  if (html && /<(ul|ol|table|blockquote|pre|h[1-6])\b/i.test(html)) {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
Public product links now live in source. Contact email and legal name stay in env.

The editor also round-trips underline, highlight, nested lists, and markdown paste, and keeps proposal diffs in a bounded scroll area.

Made with [Cursor](https://cursor.com)